### PR TITLE
Add MYSTK creator Flask prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # AthenosAI
+
+This repository contains a simple Flask application for **MYSTK creators**. The web app provides three main sections:
+
+1. **Learn** – creators can access learning resources.
+2. **Metrics** – view monthly metrics.
+3. **Support** – get in touch with support.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the app:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000` in your browser.
+
+## Running Tests
+
+The repo includes simple tests using `pytest`.
+To run them execute:
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,22 @@
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return jsonify({"message": "Welcome to the MYSTK creators portal"})
+
+@app.route('/learn')
+def learn():
+    return jsonify({"section": "learn", "content": "Learning resources placeholder"})
+
+@app.route('/metrics')
+def metrics():
+    return jsonify({"section": "metrics", "content": "Monthly metrics placeholder"})
+
+@app.route('/support')
+def support():
+    return jsonify({"section": "support", "content": "Support information placeholder"})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Werkzeug<3
+Flask==2.3.2
+pytest==7.4.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,31 @@
+import sys, os; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app
+
+def test_index():
+    client = app.app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert resp.get_json().get('message') == 'Welcome to the MYSTK creators portal'
+
+def test_learn():
+    client = app.app.test_client()
+    resp = client.get('/learn')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get('section') == 'learn'
+
+
+def test_metrics():
+    client = app.app.test_client()
+    resp = client.get('/metrics')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get('section') == 'metrics'
+
+
+def test_support():
+    client = app.app.test_client()
+    resp = client.get('/support')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get('section') == 'support'


### PR DESCRIPTION
## Summary
- build a simple Flask web app with endpoints for learn, metrics and support
- document setup and usage in README
- include requirements and a .gitignore
- add pytest suite covering the endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b387548948321958fd0b5bd5940c6